### PR TITLE
Added support for Ag.vim and Ack.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ option set to something like this:
     nmap <leader><leader>g <Plug>GrepOperatorWithFilenamePrompt
     vmap <leader><leader>g <Plug>GrepOperatorWithFilenamePrompt
 
+## Choose your grep operator (default: grep)
+
+    let g:grep_operator = "ag"
+    let g:grep_operator = "ack"
+
 ## Examples
 
 `<leader>giw` will grep the current directory for the word under the cursor and

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ option set to something like this:
 
     let g:grep_operator = "Ag"
     let g:grep_operator = "Ack"
-    let g:grep_operator = [ "Ag", "Ack" ]
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ option set to something like this:
 
     let g:grep_operator = "Ag"
     let g:grep_operator = "Ack"
+    let g:grep_operator = [ "Ag", "Ack" ]
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ option set to something like this:
 
 ## Choose your grep operator (default: grep)
 
-    let g:grep_operator = "ag"
-    let g:grep_operator = "ack"
+    let g:grep_operator = "Ag"
+    let g:grep_operator = "Ack"
 
 ## Examples
 

--- a/autoload/grep_operator.vim
+++ b/autoload/grep_operator.vim
@@ -51,24 +51,26 @@ function! grep_operator#GetPattern(type) " {{{
 endfunction
 " }}}
 
+function! grep_operator#IsPreferredOperatorAvailable(operator) "{{{
+    if exists(":" . a:operator)
+        return 1
+    endif
+
+    return 0
+endfunction
+" }}}
+
 function! grep_operator#Grep(pattern, filenames) " {{{
     " Execute the command and don't jump to the first match (The :grep! form
     " does that)
-    let operator = 'grep!'
+    let operator = 'grep'
     if exists("g:grep_operator") &&
-                \ (g:grep_operator ==? "ag") &&
-                \ executable("ag") &&
-                \ exists(":Ag")
-        let operator = 'Ag!'
-    elseif exists("g:grep_operator") &&
-                \ (g:grep_operator ==? "ack") &&
-                \ executable("ack") &&
-                \ exists(":Ack")
-        let operator = 'Ack!'
+                \ grep_operator#IsPreferredOperatorAvailable(g:grep_operator)
+        let operator = g:grep_operator
     endif
 
     silent execute
-                \ operator . ' ' . shellescape(a:pattern) . ' ' .
+                \ operator . '! ' . shellescape(a:pattern) . ' ' .
                 \ join(map(copy(a:filenames), "shellescape(v:val)"), ' ')
 endfunction
 " }}}

--- a/autoload/grep_operator.vim
+++ b/autoload/grep_operator.vim
@@ -61,23 +61,15 @@ endfunction
 " }}}
 
 function! grep_operator#Grep(pattern, filenames) " {{{
-    " Execute the command and don't jump to the first match (The :grep! form
-    " does that)
-    let operator = 'grep'
-    if exists("g:grep_operator")
-        if type(g:grep_operator) == type("")
-            if grep_operator#IsPreferredOperatorAvailable(g:grep_operator)
-                let operator = g:grep_operator
-            endif
-        elseif type(g:grep_operator) == type([])
-            for oper in reverse(g:grep_operator)
-                if grep_operator#IsPreferredOperatorAvailable(oper)
-                    let operator = oper
-                endif
-            endfor
-        endif
+    " Get the operator specified by the user
+    let operator = get(g:, 'grep_operator', 'grep')
+    if !grep_operator#IsPreferredOperatorAvailable(operator)
+        " If it's not available fallback to grep
+        let operator = 'grep'
     endif
 
+    " Execute the command and don't jump to the first match (The :grep! form
+    " does that)
     silent execute
                 \ operator . '! ' . shellescape(a:pattern) . ' ' .
                 \ join(map(copy(a:filenames), "shellescape(v:val)"), ' ')

--- a/autoload/grep_operator.vim
+++ b/autoload/grep_operator.vim
@@ -54,10 +54,22 @@ endfunction
 function! grep_operator#Grep(pattern, filenames) " {{{
     " Execute the command and don't jump to the first match (The :grep! form
     " does that)
+    let operator = 'grep!'
+    if exists("g:grep_operator") &&
+                \ (g:grep_operator ==? "ag") &&
+                \ executable("ag") &&
+                \ exists(":Ag")
+        let operator = 'Ag!'
+    elseif exists("g:grep_operator") &&
+                \ (g:grep_operator ==? "ack") &&
+                \ executable("ack") &&
+                \ exists(":Ack")
+        let operator = 'Ack!'
+    endif
+
     silent execute
-                \ 'grep! '
-                \ . shellescape(a:pattern) . ' '
-                \ . join(map(copy(a:filenames), "shellescape(v:val)"), ' ')
+                \ operator . ' ' . shellescape(a:pattern) . ' ' .
+                \ join(map(copy(a:filenames), "shellescape(v:val)"), ' ')
 endfunction
 " }}}
 

--- a/autoload/grep_operator.vim
+++ b/autoload/grep_operator.vim
@@ -64,9 +64,18 @@ function! grep_operator#Grep(pattern, filenames) " {{{
     " Execute the command and don't jump to the first match (The :grep! form
     " does that)
     let operator = 'grep'
-    if exists("g:grep_operator") &&
-                \ grep_operator#IsPreferredOperatorAvailable(g:grep_operator)
-        let operator = g:grep_operator
+    if exists("g:grep_operator")
+        if type(g:grep_operator) == type("")
+            if grep_operator#IsPreferredOperatorAvailable(g:grep_operator)
+                let operator = g:grep_operator
+            endif
+        elseif type(g:grep_operator) == type([])
+            for oper in reverse(g:grep_operator)
+                if grep_operator#IsPreferredOperatorAvailable(oper)
+                    let operator = oper
+                endif
+            endfor
+        endif
     endif
 
     silent execute

--- a/doc/grep-operator.txt
+++ b/doc/grep-operator.txt
@@ -57,7 +57,6 @@ ag/ack with one of the following commands:
 
     let g:grep_operator = "Ag"
     let g:grep_operator = "Ack"
-    let g:grep_operator = [ "Ag", "Ack" ]
 
 
 ==============================================================================

--- a/doc/grep-operator.txt
+++ b/doc/grep-operator.txt
@@ -57,6 +57,7 @@ ag/ack with one of the following commands:
 
     let g:grep_operator = "Ag"
     let g:grep_operator = "Ack"
+    let g:grep_operator = [ "Ag", "Ack" ]
 
 
 ==============================================================================

--- a/doc/grep-operator.txt
+++ b/doc/grep-operator.txt
@@ -51,12 +51,12 @@ and won't overwrite any of your settings. The recommended mappings are:
 3. Operators                                           *GrepOperatorOperators*
 
 This plugin allows the user to specify if they would like to use grep,
-ag or ack. If the operator isn't specified or Ag.vim/Ack.vim isn't
-installed, it defaults to grep. You can use ag/ack with one of the
-following commands:
+ag, ack, or something else. If the operator isn't specified or
+Ag.vim/Ack.vim isn't installed, it defaults to grep. You can use
+ag/ack with one of the following commands:
 
-    let g:grep_operator = "ag"
-    let g:grep_operator = "ack"
+    let g:grep_operator = "Ag"
+    let g:grep_operator = "Ack"
 
 
 ==============================================================================

--- a/doc/grep-operator.txt
+++ b/doc/grep-operator.txt
@@ -19,7 +19,8 @@ CONTENTS                                                *GrepOperatorContents*
 
     1. Introduction ......... |GrepOperatorIntroduction|
     2. Mappings ............. |GrepOperatorMappings|
-    3. Examples ............. |GrepOperatorExamples|
+    3. Operators ............ |GrepOperatorOperators|
+    4. Examples ............. |GrepOperatorExamples|
 
 
 ==============================================================================
@@ -47,7 +48,19 @@ and won't overwrite any of your settings. The recommended mappings are:
 
 
 ==============================================================================
-3. Examples                                             *GrepOperatorExamples*
+3. Operators                                           *GrepOperatorOperators*
+
+This plugin allows the user to specify if they would like to use grep,
+ag or ack. If the operator isn't specified or Ag.vim/Ack.vim isn't
+installed, it defaults to grep. You can use ag/ack with one of the
+following commands:
+
+    let g:grep_operator = "ag"
+    let g:grep_operator = "ack"
+
+
+==============================================================================
+4. Examples                                             *GrepOperatorExamples*
 
 <leader>giw will grep the current directory for the word under the cursor and
 open the quickfix window.


### PR DESCRIPTION
Added a variable that lets the user specify if they would prefer to use ag (the_silver_searcher) or ack instead of grep. If Ag.vim/Ack.vim is not installed, or ag/ack is not installed, then it falls back to grep.
